### PR TITLE
Patch 1

### DIFF
--- a/awesome-grid.js
+++ b/awesome-grid.js
@@ -61,8 +61,11 @@ THE SOFTWARE.
                 $.each((self.options.columns), function(key, val){
                     if(parseInt(key) && (window.innerWidth <= parseInt(key)))
                     {
-                        columns = parseInt(val);
-                        set = true;
+                        if (!mediaQuery || mediaQuery > parseInt(key)) {
+                            columns = parseInt(val);
+                            set = true;
+                            mediaQuery = parseInt(key);
+                        }
                     }
                 });
                 if(!set)

--- a/awesome-grid.js
+++ b/awesome-grid.js
@@ -56,6 +56,7 @@ THE SOFTWARE.
             var self = this;
             var columns = 2;
             var set = false;
+            var mediaQuery = false;
             if(!parseInt(self.options.columns))
             {
                 $.each((self.options.columns), function(key, val){


### PR DESCRIPTION
For some reaction (maybe order of elements) the columns options do not executes as wanted.

``` javascript
$('elm').AwesomeGrid({
  'columns': {
    'defaults': 5,
    '1200': 4, // more than one kind of media query
    '800': 3,
    '500': 2
  }
});
```

This update resolves this issue.
